### PR TITLE
Ignore from the IgnoreInComparisonAttribute

### DIFF
--- a/ObjectsComparer/ObjectsComparer.Tests/Comparer_GenericEnumerableTests.cs
+++ b/ObjectsComparer/ObjectsComparer.Tests/Comparer_GenericEnumerableTests.cs
@@ -226,6 +226,128 @@ namespace ObjectsComparer.Tests
             Assert.AreEqual("Child3", differences.First().Value2);
         }
 
+
+
+        [Test]
+        public void IgnoreAttributeComparisonDeepEquality()
+        {
+          var a1 = new Parent();
+          a1.Child1.Add(new ParentChild(a1,
+                                        "Child1",
+                                        new ObservableCollection <Child>
+                                        {
+                                            new Child("p1",
+                                                      "p2"),
+                                            new Child("p3",
+                                                      "p4")
+                                        }
+                                       ));
+          a1.Child1.Add(new ParentChild(a1,
+                                        "Child2",
+                                        new ObservableCollection <Child>
+                                        {
+                                            new Child("p1",
+                                                      "p2"),
+                                            new Child("p3",
+                                                      "p4")
+                                        }
+                                       ));
+
+          var a2 = new Parent();
+          a2.Child1.Add(new ParentChild(a1,
+                                        "Child1",
+                                        new ObservableCollection <Child>
+                                        {
+                                            new Child("p1",
+                                                      "p2"),
+                                            new Child("p3",
+                                                      "p4")
+                                        }
+                                       ));
+          a2.Child1.Add(new ParentChild(a1,
+                                        "Child2",
+                                        new ObservableCollection <Child>
+                                        {
+                                            new Child("p1",
+                                                      "p2"),
+                                            new Child("p3",
+                                                      "p5")
+                                        }
+                                       ));
+
+          var comparer = new Comparer <Parent>();
+
+          var isEqual = comparer.Compare(a1,
+                                         a2);
+
+          Assert.IsTrue(isEqual);
+        }
+
+
+
+        [Test]
+        public void IgnoreAttributeComparisonDeepInEquality()
+        {
+          var a1 = new Parent();
+          a1.Child1.Add(new ParentChild(a1,
+                                        "Child1",
+                                        new ObservableCollection <Child>
+                                        {
+                                            new Child("p1",
+                                                      "p2"),
+                                            new Child("p3",
+                                                      "p4")
+                                        }
+                                       ));
+          a1.Child1.Add(new ParentChild(a1,
+                                        "Child2",
+                                        new ObservableCollection <Child>()
+                                        {
+                                            new Child("p1",
+                                                      "p2"),
+                                            new Child("p3",
+                                                      "p4")
+                                        }
+                                       ));
+
+          var a2 = new Parent();
+          a2.Child1.Add(new ParentChild(a1,
+                                        "Child1",
+                                        new ObservableCollection <Child>
+                                        {
+                                            new Child("p1",
+                                                      "p2"),
+                                            new Child("p3",
+                                                      "p4")
+                                        }
+                                       ));
+          a2.Child1.Add(new ParentChild(a1,
+                                        "Child2",
+                                        new ObservableCollection <Child>
+                                        {
+                                            new Child("p1",
+                                                      "p2"),
+                                            new Child("p5",
+                                                      "p6")
+                                        }
+                                       ));
+
+          var comparer = new Comparer <Parent>();
+
+          var differences = comparer.CalculateDifferences(a1,
+                                                          a2).ToList();
+
+          CollectionAssert.IsNotEmpty(differences);
+          Assert.AreEqual("Child1[1].Children[1].Property1",
+                          differences.First().MemberPath);
+          Assert.AreEqual("p3",
+                          differences.First().Value1);
+          Assert.AreEqual("p5",
+                          differences.First().Value2);
+        }
+
+
+
         [Test]
         public void CollectionInequalityProperty()
         {
@@ -547,7 +669,7 @@ namespace ObjectsComparer.Tests
             var differences = comparer.CalculateDifferences(a1, a2).ToList();
 
             Assert.AreEqual(1, differences.Count);
-            Assert.AreEqual(DifferenceTypes.MissedElementInFirstObject, differences.First().DifferenceType);
+            Assert.AreEqual(DifferenceTypes.NumberOfElementsMismatch, differences.First().DifferenceType);
         }
 
         [Test]

--- a/ObjectsComparer/ObjectsComparer.Tests/TestClasses/Child.cs
+++ b/ObjectsComparer/ObjectsComparer.Tests/TestClasses/Child.cs
@@ -1,0 +1,27 @@
+﻿namespace ObjectsComparer.Tests.TestClasses
+{
+  using ObjectsComparer.Attributes;
+
+  public class Child
+  {
+    #region Constructors
+
+    public Child(string property1,
+                 string property2)
+    {
+      this.Property1 = property1;
+      this.Property2 = property2;
+    }
+
+    #endregion
+
+    #region Properties
+
+    public string Property1 { get; set; }
+
+    [IgnoreInComparison]
+    public string Property2 { get; set; }
+
+    #endregion
+  }
+}

--- a/ObjectsComparer/ObjectsComparer.Tests/TestClasses/ParentChild.cs
+++ b/ObjectsComparer/ObjectsComparer.Tests/TestClasses/ParentChild.cs
@@ -1,5 +1,9 @@
 ﻿namespace ObjectsComparer.Tests.TestClasses
 {
+  using System.Collections.ObjectModel;
+
+  using NUnit.Framework;
+
   using ObjectsComparer.Attributes;
 
   public class ParentChild
@@ -13,6 +17,17 @@
       this.Property1 = property1;
     }
 
+
+
+    public ParentChild(Parent myParent,
+                       string property1,
+                       ObservableCollection <Child> children)
+    {
+      this.MyParent = myParent;
+      this.Property1 = property1;
+      this.Children = children;
+    }
+
     #endregion
 
     #region Properties
@@ -21,6 +36,8 @@
 
     [IgnoreInComparison]
     public Parent MyParent { get; set; }
+
+    public ObservableCollection <Child> Children { get; set; } = new ObservableCollection <Child>();
 
     #endregion
   }

--- a/ObjectsComparer/ObjectsComparer/Comparer~1.cs
+++ b/ObjectsComparer/ObjectsComparer/Comparer~1.cs
@@ -110,6 +110,11 @@ namespace ObjectsComparer
 
             foreach (var member in _members)
             {
+                if (member.GetCustomAttributes(true).Any(c => c is IgnoreInComparisonAttribute))
+                {
+                  continue;
+                }
+
                 var value1 = member.GetMemberValue(obj1);
                 var value2 = member.GetMemberValue(obj2);
                 var type = member.GetMemberType();


### PR DESCRIPTION
There was a bug while comparing the list of object. The comparer was not ignoring the members of the list item. I have fixed the issue. Please approve the change and merge it.